### PR TITLE
fix: 🐛 clean duplicated content from RSS

### DIFF
--- a/tiddlers/$__plugins_adithyab_tiddlyjam_renderer_rss.tid
+++ b/tiddlers/$__plugins_adithyab_tiddlyjam_renderer_rss.tid
@@ -1,6 +1,6 @@
 created: 20200913085259429
 creator: TJ
-modified: 20241105073351911
+modified: 20241105080147805
 modifier: TJ
 tags: $:/plugins/adithyab/tiddlyjam/internals
 title: $:/plugins/adithyab/tiddlyjam/renderer/rss
@@ -22,7 +22,7 @@ type: text/vnd.tiddlywiki
    &lt;item&gt;
       &lt;title&gt;{{!!title}}&lt;/title&gt;
       &lt;link&gt;<$text text={{$:/AbsoluteBaseUrl}}/>/<$macrocall $name="tv-get-export-path" title={{!!title}}/>&lt;/link&gt;
-			&lt;description&gt;&lt;![CDATA[<$wikify name="output" text={{$:/plugins/adithyab/tiddlyjam/renderer/base/converter}} mode="inline" output="html"><$text text=<<output>>/></$wikify>]]&gt;&lt;/description&gt;
+			&lt;description&gt;&lt;![CDATA[<$wikify name="output" text={{$:/plugins/adithyab/tiddlyjam/renderer/rss/converter}} mode="inline" output="html"><$text text=<<output>>/></$wikify>]]&gt;&lt;/description&gt;
       &lt;pubDate&gt;<$list filter="[{!!published}is[blank]then{!!created}else{!!published}]"><$view field="title" format="date" template="ddd, DD MMM YYYY hh:mm:ss TZD" /></$list>&lt;/pubDate&gt;
 			&lt;guid&gt;<$text text={{$:/AbsoluteBaseUrl}}/>/<$macrocall $name="tv-get-export-path" title={{!!title}}/>&lt;/guid&gt;      
    &lt;/item&gt;

--- a/tiddlers/$__plugins_adithyab_tiddlyjam_renderer_rss_body.tid
+++ b/tiddlers/$__plugins_adithyab_tiddlyjam_renderer_rss_body.tid
@@ -1,0 +1,17 @@
+created: 20241105075601260
+creator: TJ
+modified: 20241105075933650
+modifier: TJ
+tags: $:/plugins/adithyab/tiddlyjam/internals
+title: $:/plugins/adithyab/tiddlyjam/renderer/rss/body
+type: text/vnd.tiddlywiki
+
+<div class="content">
+  <$list filter="[all[current]]">
+
+    <$transclude />
+
+  </$list>
+</div>
+
+{{$:/plugins/adithyab/tiddlyjam/renderer/blog/license}}

--- a/tiddlers/$__plugins_adithyab_tiddlyjam_renderer_rss_converter.tid
+++ b/tiddlers/$__plugins_adithyab_tiddlyjam_renderer_rss_converter.tid
@@ -1,0 +1,10 @@
+created: 20241105075725142
+creator: TJ
+modified: 20241105075740951
+tags: $:/plugins/adithyab/tiddlyjam/internals
+title: $:/plugins/adithyab/tiddlyjam/renderer/rss/converter
+type: text/vnd.tiddlywiki
+
+<$list filter="[<currentTiddler>tags[][$:/plugins/adithyab/tiddlyjam/renderer/rss/body]]" variable="listItem">
+<$transclude tiddler=<<listItem>>/>
+</$list>


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/0e4a0357-1bb9-42ab-b889-3aeb480d0a86)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the RSS renderer to enhance description content processing in feeds.
	- Introduced a new body file for the RSS renderer, allowing dynamic inclusion of tiddler content.
	- Added a new converter file that enables flexible rendering of tiddlers tagged for RSS.

- **Bug Fixes**
	- Corrected the path in the RSS description element for improved functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->